### PR TITLE
:rocket: feat: endpoint de cadastro de usuário (POST /api/users/save)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-crypto</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <optional>true</optional>
@@ -215,6 +220,18 @@
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>

--- a/src/main/java/api/core/stream_video_backend/modules/configuration/ModelMapperConfig.java
+++ b/src/main/java/api/core/stream_video_backend/modules/configuration/ModelMapperConfig.java
@@ -3,11 +3,18 @@ package api.core.stream_video_backend.modules.configuration;
 import org.modelmapper.ModelMapper;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Configuration
 public class ModelMapperConfig {
     @Bean
     public ModelMapper modelMapper() {
         return new ModelMapper();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
     }
 }

--- a/src/main/java/api/core/stream_video_backend/modules/exceptions/EmailAlreadyExistsException.java
+++ b/src/main/java/api/core/stream_video_backend/modules/exceptions/EmailAlreadyExistsException.java
@@ -1,0 +1,8 @@
+package api.core.stream_video_backend.modules.exceptions;
+
+public class EmailAlreadyExistsException extends RuntimeException {
+
+    public EmailAlreadyExistsException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/api/core/stream_video_backend/modules/users/controller/UsersApi.java
+++ b/src/main/java/api/core/stream_video_backend/modules/users/controller/UsersApi.java
@@ -1,6 +1,27 @@
 package api.core.stream_video_backend.modules.users.controller;
 
+import api.core.stream_video_backend.modules.users.dto.request.UsersRequest;
+import api.core.stream_video_backend.modules.users.dto.response.UsersResponse;
+import api.core.stream_video_backend.modules.users.services.UsersServices;
+import jakarta.validation.Valid;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
+@RestController
+@RequestMapping("/api/users")
 public class UsersApi {
 
+    @Autowired
+    private UsersServices usersServices;
+
+    @PostMapping("/save")
+    public ResponseEntity<UsersResponse> register(@Valid @RequestBody UsersRequest request) {
+        UsersResponse response = usersServices.registerUser(request);
+        return new ResponseEntity<>(response, HttpStatus.CREATED);
+    }
 }

--- a/src/main/java/api/core/stream_video_backend/modules/users/controller/UsersApi.java
+++ b/src/main/java/api/core/stream_video_backend/modules/users/controller/UsersApi.java
@@ -4,7 +4,7 @@ import api.core.stream_video_backend.modules.users.dto.request.UsersRequest;
 import api.core.stream_video_backend.modules.users.dto.response.UsersResponse;
 import api.core.stream_video_backend.modules.users.services.UsersServices;
 import jakarta.validation.Valid;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -14,14 +14,13 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/users")
+@RequiredArgsConstructor
 public class UsersApi {
 
-    @Autowired
-    private UsersServices usersServices;
+    private final UsersServices usersServices;
 
     @PostMapping("/save")
     public ResponseEntity<UsersResponse> register(@Valid @RequestBody UsersRequest request) {
-        UsersResponse response = usersServices.registerUser(request);
-        return new ResponseEntity<>(response, HttpStatus.CREATED);
+        return ResponseEntity.status(HttpStatus.CREATED).body(usersServices.registerUser(request));
     }
 }

--- a/src/main/java/api/core/stream_video_backend/modules/users/dto/request/UsersRequest.java
+++ b/src/main/java/api/core/stream_video_backend/modules/users/dto/request/UsersRequest.java
@@ -1,3 +1,30 @@
 package api.core.stream_video_backend.modules.users.dto.request;
 
-public record UsersRequest() {}
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UsersRequest {
+    @NotBlank
+    @Size(min = 3, max = 100)
+    private String name;
+
+    @NotBlank
+    @Email
+    @Size(max = 255)
+    private String email;
+
+    @NotBlank
+    @Size(min = 6, max = 255)
+    private String password;
+}

--- a/src/main/java/api/core/stream_video_backend/modules/users/dto/request/UsersRequest.java
+++ b/src/main/java/api/core/stream_video_backend/modules/users/dto/request/UsersRequest.java
@@ -3,28 +3,18 @@ package api.core.stream_video_backend.modules.users.dto.request;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
 
-@Getter
-@Setter
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
-public class UsersRequest {
-    @NotBlank
-    @Size(min = 3, max = 100)
-    private String name;
+public record UsersRequest(
+        @NotBlank
+        @Size(min = 3, max = 100)
+        String name,
 
-    @NotBlank
-    @Email
-    @Size(max = 255)
-    private String email;
+        @NotBlank
+        @Email
+        @Size(max = 255)
+        String email,
 
-    @NotBlank
-    @Size(min = 6, max = 255)
-    private String password;
-}
+        @NotBlank
+        @Size(min = 6, max = 255)
+        String password
+) {}

--- a/src/main/java/api/core/stream_video_backend/modules/users/dto/response/UsersResponse.java
+++ b/src/main/java/api/core/stream_video_backend/modules/users/dto/response/UsersResponse.java
@@ -1,3 +1,27 @@
 package api.core.stream_video_backend.modules.users.dto.response;
 
-public record UsersResponse() {}
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UsersResponse {
+    @NotBlank
+    @Size(min = 3, max = 60)
+    String name;
+
+    @NotBlank
+    @Email
+    @Size(max = 100)
+    String email;
+}
+

--- a/src/main/java/api/core/stream_video_backend/modules/users/dto/response/UsersResponse.java
+++ b/src/main/java/api/core/stream_video_backend/modules/users/dto/response/UsersResponse.java
@@ -1,27 +1,6 @@
 package api.core.stream_video_backend.modules.users.dto.response;
 
-import jakarta.validation.constraints.Email;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Size;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
-
-@Getter
-@Setter
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
-public class UsersResponse {
-    @NotBlank
-    @Size(min = 3, max = 60)
-    String name;
-
-    @NotBlank
-    @Email
-    @Size(max = 100)
-    String email;
-}
-
+public record UsersResponse(
+        String name,
+        String email
+) {}

--- a/src/main/java/api/core/stream_video_backend/modules/users/model/Users.java
+++ b/src/main/java/api/core/stream_video_backend/modules/users/model/Users.java
@@ -29,6 +29,7 @@ public class Users implements Serializable {
     @Column(name = "avatar", columnDefinition = "TEXT")
     private String avatar;
 
+    @Column(unique = true)
     private String email;
 
     private String password;

--- a/src/main/java/api/core/stream_video_backend/modules/users/repository/UsersRepository.java
+++ b/src/main/java/api/core/stream_video_backend/modules/users/repository/UsersRepository.java
@@ -8,4 +8,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface UsersRepository extends JpaRepository<Users, Long> {
 
+    java.util.Optional<Users> findByEmail(String email);
+
 }

--- a/src/main/java/api/core/stream_video_backend/modules/users/repository/UsersRepository.java
+++ b/src/main/java/api/core/stream_video_backend/modules/users/repository/UsersRepository.java
@@ -4,10 +4,11 @@ import api.core.stream_video_backend.modules.users.model.Users;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
 
 @Repository
 public interface UsersRepository extends JpaRepository<Users, Long> {
 
-    java.util.Optional<Users> findByEmail(String email);
+    Optional<Users> findByEmail(String email);
 
 }

--- a/src/main/java/api/core/stream_video_backend/modules/users/services/UsersServices.java
+++ b/src/main/java/api/core/stream_video_backend/modules/users/services/UsersServices.java
@@ -1,7 +1,40 @@
 package api.core.stream_video_backend.modules.users.services;
 
+import api.core.stream_video_backend.modules.users.dto.request.UsersRequest;
+import api.core.stream_video_backend.modules.users.dto.response.UsersResponse;
+import api.core.stream_video_backend.modules.users.model.Users;
+import api.core.stream_video_backend.modules.users.repository.UsersRepository;
+import org.modelmapper.ModelMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
 
 @Service
 public class UsersServices {
+
+    @Autowired
+    private UsersRepository usersRepository;
+
+    @Autowired
+    private ModelMapper modelMapper;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    public UsersResponse registerUser(UsersRequest request) {
+        if (usersRepository.findByEmail(request.getEmail()).isPresent()) {
+            throw new RuntimeException("Email já existe");
+        }
+
+        Users users = modelMapper.map(request, Users.class);
+        users.setPassword(passwordEncoder.encode(request.getPassword()));
+        users.setCreatedAt(LocalDateTime.now());
+        users.setUpdatedAt(LocalDateTime.now());
+        users.setStatus(true);
+
+        Users saved = usersRepository.save(users);
+        return modelMapper.map(saved, UsersResponse.class);
+    }
 }

--- a/src/main/java/api/core/stream_video_backend/modules/users/services/UsersServices.java
+++ b/src/main/java/api/core/stream_video_backend/modules/users/services/UsersServices.java
@@ -1,40 +1,39 @@
 package api.core.stream_video_backend.modules.users.services;
 
+import api.core.stream_video_backend.modules.exceptions.EmailAlreadyExistsException;
 import api.core.stream_video_backend.modules.users.dto.request.UsersRequest;
 import api.core.stream_video_backend.modules.users.dto.response.UsersResponse;
 import api.core.stream_video_backend.modules.users.model.Users;
 import api.core.stream_video_backend.modules.users.repository.UsersRepository;
-import org.modelmapper.ModelMapper;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
 
 @Service
+@RequiredArgsConstructor
 public class UsersServices {
 
-    @Autowired
-    private UsersRepository usersRepository;
-
-    @Autowired
-    private ModelMapper modelMapper;
-
-    @Autowired
-    private PasswordEncoder passwordEncoder;
+    private final UsersRepository usersRepository;
+    private final PasswordEncoder passwordEncoder;
 
     public UsersResponse registerUser(UsersRequest request) {
-        if (usersRepository.findByEmail(request.getEmail()).isPresent()) {
-            throw new RuntimeException("Email já existe");
+        if (usersRepository.findByEmail(request.email()).isPresent()) {
+            throw new EmailAlreadyExistsException("Email já existe");
         }
 
-        Users users = modelMapper.map(request, Users.class);
-        users.setPassword(passwordEncoder.encode(request.getPassword()));
-        users.setCreatedAt(LocalDateTime.now());
-        users.setUpdatedAt(LocalDateTime.now());
-        users.setStatus(true);
+        LocalDateTime now = LocalDateTime.now();
+        Users users = Users.builder()
+                .name(request.name())
+                .email(request.email())
+                .password(passwordEncoder.encode(request.password()))
+                .createdAt(now)
+                .updatedAt(now)
+                .status(true)
+                .build();
 
         Users saved = usersRepository.save(users);
-        return modelMapper.map(saved, UsersResponse.class);
+        return new UsersResponse(saved.getName(), saved.getEmail());
     }
 }


### PR DESCRIPTION
.  Descrição
Adiciona o endpoint de cadastro de usuário com hash de senha (BCrypt) e aplica
os ajustes de arquitetura apontados no review do PR #82 (fechado).

. O que foi feito
- `POST /api/users/save` — cria usuário, senha com BCrypt, validação de e-mail único
- `UsersRequest` / `UsersResponse` como **record** (regra `..dto..` → `beRecords`)
- **Constructor injection** (`@RequiredArgsConstructor`) em `UsersApi` e `UsersServices` — sem field injection
- Mapeamento via `Users.builder()` + construtor no lugar de `ModelMapper` (remove CodeSmell de duplicação)
- `findByEmail` no `UsersRepository` com import de `java.util.Optional` (sem FQN)
- Controller delega via `ResponseEntity.status().body()` — sem instanciar objeto na controladora
- `EmailAlreadyExistsException` custom no lugar de `RuntimeException`
- `@Column(unique = true)` no e-mail (`Users`)
- Deps: `lombok` (annotation processor) + `spring-security-crypto` (`pom.xml`)

