### PR TITLE
Implementa listagem de vídeos por categoria (#27)

### DIFF
--- a/src/main/java/api/core/streamx/modules/videos/controller/VideosController.java
+++ b/src/main/java/api/core/streamx/modules/videos/controller/VideosController.java
@@ -1,22 +1,26 @@
 package api.core.streamx.modules.videos.controller;
 
+import api.core.streamx.modules.videos.dto.response.VideosResponse;
 import api.core.streamx.modules.videos.services.VideosServices;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-@RequiredArgsConstructor
+import java.util.List;
+
 @RestController
-@RequestMapping(path = "")
+@RequestMapping(path = "/api/video")
+@RequiredArgsConstructor
 public class VideosController {
 
     private final VideosServices videosServices;
 
-    @GetMapping
-    public ResponseEntity<?> videos() {
-        return null;
+    @GetMapping("/category")
+    public ResponseEntity<List<VideosResponse>> listVideosByCategory(@RequestParam(name = "category_id") Long categoryId) {
+        return ResponseEntity.ok(videosServices.listVideosByCategory(categoryId));
     }
 
 }

--- a/src/main/java/api/core/streamx/modules/videos/dto/response/VideosResponse.java
+++ b/src/main/java/api/core/streamx/modules/videos/dto/response/VideosResponse.java
@@ -1,4 +1,10 @@
 package api.core.streamx.modules.videos.dto.response;
 
-public record VideosResponse() {
-}
+public record VideosResponse(
+        Long id,
+        String channelName,
+        String title,
+        String thumbnailUrl,
+        Integer durationSeconds,
+        Long viewCount
+) {}

--- a/src/main/java/api/core/streamx/modules/videos/repository/VideosRepository.java
+++ b/src/main/java/api/core/streamx/modules/videos/repository/VideosRepository.java
@@ -4,8 +4,9 @@ import api.core.streamx.modules.videos.model.Video;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-@Repository
-public interface VideosRepository extends JpaRepository<Video, Long>
-{
+import java.util.List;
 
+@Repository
+public interface VideosRepository extends JpaRepository<Video, Long> {
+    List<Video> findByCategoryId(Long categoryId);
 }

--- a/src/main/java/api/core/streamx/modules/videos/services/VideosServices.java
+++ b/src/main/java/api/core/streamx/modules/videos/services/VideosServices.java
@@ -1,12 +1,31 @@
 package api.core.streamx.modules.videos.services;
 
+import api.core.streamx.modules.videos.dto.response.VideosResponse;
+import api.core.streamx.modules.videos.model.Video;
 import api.core.streamx.modules.videos.repository.VideosRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @RequiredArgsConstructor
 @Service
 public class VideosServices {
 
     private final VideosRepository videosRepository;
+    public List<VideosResponse> listVideosByCategory(Long categoryId) {
+        List<Video> videos = videosRepository.findByCategoryId(categoryId);
+        return  videos.stream()
+
+            .map(video -> new VideosResponse(
+                    video.getId(),
+                    video.getChannelName(),
+                    video.getTitle(),
+                    video.getThumbnailUrl(),
+                    video.getDurationSeconds(),
+                    video.getViewCount()
+            ))
+            .toList();
+    }
+
 }

--- a/src/test/java/api/core/streamx/integration/videos/VideosIntegrationTest.java
+++ b/src/test/java/api/core/streamx/integration/videos/VideosIntegrationTest.java
@@ -8,6 +8,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultMatcher;
 
 import java.util.List;
 
@@ -47,7 +48,12 @@ public class VideosIntegrationTest {
                         .param("category_id", String.valueOf(categoryId)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$[0].id").value(1L))
-                .andExpect(jsonPath("$[0].title").value("Vídeo Teste"));
+                .andExpect(jsonPath("$[0].channelName").value("Canal Teste"))
+                .andExpect(jsonPath("$[0].title").value("Vídeo Teste"))
+                .andExpect(jsonPath("$[0].thumbnailUrl").value("http://..."))
+                .andExpect(jsonPath("$[0].durationSeconds").value(600))
+                .andExpect(jsonPath("$[0].viewCount").value(1000L));
+
 
         verify(videosServices).listVideosByCategory(categoryId);
     }

--- a/src/test/java/api/core/streamx/integration/videos/VideosIntegrationTest.java
+++ b/src/test/java/api/core/streamx/integration/videos/VideosIntegrationTest.java
@@ -53,7 +53,19 @@ public class VideosIntegrationTest {
                 .andExpect(jsonPath("$[0].thumbnailUrl").value("http://..."))
                 .andExpect(jsonPath("$[0].durationSeconds").value(600))
                 .andExpect(jsonPath("$[0].viewCount").value(1000L));
+        verify(videosServices).listVideosByCategory(categoryId);
+    }
 
+    @Test
+    void shouldReturnEmptyListWhenCategoryHasNoVideos() throws Exception {
+        Long categoryId = 99L;
+
+        when(videosServices.listVideosByCategory(categoryId)).thenReturn(List.of());
+
+        mockMvc.perform(get("/api/video/category")
+                        .param("category_id", String.valueOf(categoryId)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isEmpty());
 
         verify(videosServices).listVideosByCategory(categoryId);
     }

--- a/src/test/java/api/core/streamx/integration/videos/VideosIntegrationTest.java
+++ b/src/test/java/api/core/streamx/integration/videos/VideosIntegrationTest.java
@@ -1,0 +1,54 @@
+package api.core.streamx.integration.videos;
+
+import api.core.streamx.modules.videos.controller.VideosController;
+import api.core.streamx.modules.videos.dto.response.VideosResponse;
+import api.core.streamx.modules.videos.services.VideosServices;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = VideosController.class)
+public class VideosIntegrationTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @MockitoBean
+    VideosServices videosServices;
+
+    @Test
+    void shouldListVideosByCategoryAndReturnOk() throws Exception {
+        Long categoryId = 1L;
+
+        VideosResponse videoFalso = new VideosResponse(
+                1L,
+                "Canal Teste",
+                "Vídeo Teste",
+                "http://...",
+                600,
+                1000L
+        );
+
+        List<VideosResponse> listaFalsa = List.of(videoFalso);
+
+        when(videosServices.listVideosByCategory(categoryId)).thenReturn(listaFalsa);
+
+        mockMvc.perform(get("/api/video/category")
+                        .param("category_id", String.valueOf(categoryId)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value(1L))
+                .andExpect(jsonPath("$[0].title").value("Vídeo Teste"));
+
+        verify(videosServices).listVideosByCategory(categoryId);
+    }
+}

--- a/src/test/java/api/core/streamx/unit/videos/VideosServicesUnitTest.java
+++ b/src/test/java/api/core/streamx/unit/videos/VideosServicesUnitTest.java
@@ -1,0 +1,55 @@
+package api.core.streamx.unit.videos;
+
+import api.core.streamx.modules.videos.dto.response.VideosResponse;
+import api.core.streamx.modules.videos.model.Video;
+import api.core.streamx.modules.videos.repository.VideosRepository;
+import api.core.streamx.modules.videos.services.VideosServices;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class VideosServicesUnitTest {
+
+    @Mock
+    VideosRepository videosRepository;
+
+    @InjectMocks
+    VideosServices videosServices;
+
+    @Test
+    void shouldReturnMappedVideosWhenCategoryHasVideos() {
+        Long categoryId = 1L;
+
+        Video video = Video.builder()
+                .id(1L)
+                .title("Vídeo Teste")
+                .channelName("Canal Teste")
+                .thumbnailUrl("http://...")
+                .durationSeconds(600)
+                .viewCount(1000L)
+                .build();
+
+        when(videosRepository.findByCategoryId(categoryId)).thenReturn(List.of(video));
+
+        List<VideosResponse> resultado = videosServices.listVideosByCategory(categoryId);
+
+        assertThat(resultado).hasSize(1);
+        assertThat(resultado.get(0).id()).isEqualTo(1L);
+        assertThat(resultado.get(0).channelName()).isEqualTo("Canal Teste");
+        assertThat(resultado.get(0).title()).isEqualTo("Vídeo Teste");
+        assertThat(resultado.get(0).thumbnailUrl()).isEqualTo("http://...");
+        assertThat(resultado.get(0).durationSeconds()).isEqualTo(600);
+        assertThat(resultado.get(0).viewCount()).isEqualTo(1000L);
+
+        verify(videosRepository).findByCategoryId(categoryId);
+    }
+}

--- a/src/test/java/api/core/streamx/unit/videos/VideosServicesUnitTest.java
+++ b/src/test/java/api/core/streamx/unit/videos/VideosServicesUnitTest.java
@@ -52,4 +52,17 @@ class VideosServicesUnitTest {
 
         verify(videosRepository).findByCategoryId(categoryId);
     }
+
+    @Test
+    void shouldReturnEmptyListWhenCategoryHasNoVideos() {
+        Long categoryId = 99L;
+
+        when(videosRepository.findByCategoryId(categoryId)).thenReturn(List.of());
+
+        List<VideosResponse> resultado = videosServices.listVideosByCategory(categoryId);
+
+        assertThat(resultado).isEmpty();
+
+        verify(videosRepository).findByCategoryId(categoryId);
+    }
 }


### PR DESCRIPTION
## Descrição
Implementa o endpoint de listagem de vídeos por categoria, conforme solicitado na issue #27.

## O que foi feito
- Adicionado `GET /api/video/category` no `VideosController`
- Criado método `listVideosByCategory` no `VideosServices`, responsável pela regra de negócio
- Adicionado `findByCategoryId` no `VideosRepository`
- Preenchido o DTO `VideosResponse` com os campos relevantes para listagem
- Adicionado teste de integração (`VideosIntegrationTest`) cobrindo o cenário de sucesso

## Como testar
1. Subir o banco (`docker-compose up -d streamx-db`)
2. Rodar a aplicação
3. Acessar `GET /api/video/category?category_id={id}` via Swagger, com um vídeo cadastrado naquela categoria

## Issue relacionada
Closes #27

_Esse é meu primeiro PR no projeto — feedbacks são muito bem-vindos!_