### PR TITLE
✨ Cria CategoryRepository estendendo JpaRepository

### DIFF
--- a/src/main/java/api/core/stream_video_backend/modules/videos/repository/CategoryRepository.java
+++ b/src/main/java/api/core/stream_video_backend/modules/videos/repository/CategoryRepository.java
@@ -1,0 +1,8 @@
+package api.core.stream_video_backend.modules.videos.repository;
+
+import api.core.stream_video_backend.modules.videos.model.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+
+}


### PR DESCRIPTION
## Descrição

Implementa a issue de criação do modelo Category e seu repositório.

## Critérios de aceitação

- [x] Classe `Category` com atributos `id` e `categoryName`
- [x] Interface `CategoryRepository` estendendo `JpaRepository<Category, Long>`
- [x] Entidade mapeada para a tabela `tb_category` (`@Table(name = "tb_category")`)

## Alterações

- Adiciona `CategoryRepository` (interface Spring Data JPA)

🤖 Generated with [Claude Code](https://claude.com/claude-code)